### PR TITLE
Add "smoke test" sketch compilation CI workflow

### DIFF
--- a/.github/workflows/compile-sketches.yml
+++ b/.github/workflows/compile-sketches.yml
@@ -32,6 +32,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -58,3 +61,11 @@ jobs:
             - name: 107-Arduino-UAVCAN
           sketch-paths: |
             - ${{ github.workspace }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save memory usage change report as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-sketches.yml
+++ b/.github/workflows/compile-sketches.yml
@@ -1,0 +1,60 @@
+name: Compile Sketch
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "!.github/workflows/compile-sketches.yml"
+      - "data/**"
+      - "**.adoc"
+      - "**.jpg"
+      - "**.md"
+      - "**.png"
+      - "**.txt"
+  push:
+    paths-ignore:
+      - ".github/**"
+      - "!.github/workflows/compile-sketches.yml"
+      - "data/**"
+      - "**.adoc"
+      - "**.jpg"
+      - "**.md"
+      - "**.png"
+      - "**.txt"
+  schedule:
+    # Run every Saturday at 6 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 6 * * SAT"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:samd:mkrzero
+            platforms: |
+              - name: arduino:samd
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            - name: 107-Arduino-Debug
+            - name: 107-Arduino-MCP2515
+            - name: 107-Arduino-NMEA-Parser
+            - name: 107-Arduino-UAVCAN
+          sketch-paths: |
+            - ${{ github.workspace }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,23 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 UAVCAN-GNSS-Node
 ================
+
+[![Compile Sketch status](https://github.com/107-systems/UAVCAN-GNSS-Node/workflows/Compile%20Sketch/badge.svg)](https://github.com/107-systems/UAVCAN-GNSS-Node/actions?workflow=Compile+Sketch)
+
 Demo firmware for UAVCAN GNSS Node utilizing [107-Arduino-UAVCAN](https://github.com/107-systems/107-Arduino-UAVCAN).
 
 **Attention**: [107-Arduino-UAVCAN](https://github.com/107-systems/107-Arduino-UAVCAN) (which provides the UAVCAN connectivity within this demo sketch) is supporting [UAVCAN](https://uavcan.org/) ([v1.0-beta](https://uavcan.org/specification/UAVCAN_Specification_v1.0-beta.pdf)). Most UAVCAN support tools do not yet support UAVCAN V1 (but legacy UAVCAN V0). Therefore the best way to interact with the UAVCAN GNSS Node is via [pyuavcan](https://github.com/UAVCAN/pyuavcan) which has already been ported to V1.


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all sketches in the repository for the specified boards.

Closes https://github.com/107-systems/UAVCAN-GNSS-Node/issues/8